### PR TITLE
Allow arcdps to be installed in addons/arcdps for gw2AL integration

### DIFF
--- a/AppSettings/ApplicationSettingsArcUpdate.cs
+++ b/AppSettings/ApplicationSettingsArcUpdate.cs
@@ -12,6 +12,9 @@ namespace PlenBotLogUploader.AppSettings
         [JsonProperty("notifications")]
         public bool Notifications { get; set; } = true;
 
+        [JsonProperty("useAL")]
+        public bool UseAL { get; set; } = false;
+
         [JsonProperty("renderMode")]
         public GameRenderMode RenderMode { get; set; } = GameRenderMode.DX11;
 

--- a/Forms/FormArcPluginManager.Designer.cs
+++ b/Forms/FormArcPluginManager.Designer.cs
@@ -36,20 +36,21 @@ namespace PlenBotLogUploader
             this.checkBoxModuleEnabled = new System.Windows.Forms.CheckBox();
             this.groupBoxModuleEnabled = new System.Windows.Forms.GroupBox();
             this.groupBoxModuleControls = new System.Windows.Forms.GroupBox();
+            this.checkBoxUseAL = new System.Windows.Forms.CheckBox();
             this.checkBoxEnableNotifications = new System.Windows.Forms.CheckBox();
             this.buttonCheckNow = new System.Windows.Forms.Button();
             this.labelStatusText = new System.Windows.Forms.Label();
             this.buttonShowPluginInfo = new System.Windows.Forms.Button();
+            this.toolTipAL = new System.Windows.Forms.ToolTip(this.components);
             this.groupBoxModuleEnabled.SuspendLayout();
             this.groupBoxModuleControls.SuspendLayout();
             this.SuspendLayout();
             // 
             // buttonChangeGW2Location
             // 
-            this.buttonChangeGW2Location.Location = new System.Drawing.Point(8, 23);
-            this.buttonChangeGW2Location.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonChangeGW2Location.Location = new System.Drawing.Point(6, 40);
             this.buttonChangeGW2Location.Name = "buttonChangeGW2Location";
-            this.buttonChangeGW2Location.Size = new System.Drawing.Size(201, 28);
+            this.buttonChangeGW2Location.Size = new System.Drawing.Size(151, 23);
             this.buttonChangeGW2Location.TabIndex = 0;
             this.buttonChangeGW2Location.Text = "Change GW2 location";
             this.buttonChangeGW2Location.UseVisualStyleBackColor = true;
@@ -64,10 +65,9 @@ namespace PlenBotLogUploader
             // 
             this.checkedListBoxArcDpsPlugins.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.checkedListBoxArcDpsPlugins.Enabled = false;
-            this.checkedListBoxArcDpsPlugins.Location = new System.Drawing.Point(241, 15);
-            this.checkedListBoxArcDpsPlugins.Margin = new System.Windows.Forms.Padding(4);
+            this.checkedListBoxArcDpsPlugins.Location = new System.Drawing.Point(181, 12);
             this.checkedListBoxArcDpsPlugins.Name = "checkedListBoxArcDpsPlugins";
-            this.checkedListBoxArcDpsPlugins.Size = new System.Drawing.Size(355, 170);
+            this.checkedListBoxArcDpsPlugins.Size = new System.Drawing.Size(266, 135);
             this.checkedListBoxArcDpsPlugins.Sorted = true;
             this.checkedListBoxArcDpsPlugins.TabIndex = 2;
             this.checkedListBoxArcDpsPlugins.SelectedIndexChanged += new System.EventHandler(this.CheckedListBoxArcDpsPlugins_SelectedIndexChanged);
@@ -75,10 +75,9 @@ namespace PlenBotLogUploader
             // checkBoxModuleEnabled
             // 
             this.checkBoxModuleEnabled.AutoSize = true;
-            this.checkBoxModuleEnabled.Location = new System.Drawing.Point(8, 23);
-            this.checkBoxModuleEnabled.Margin = new System.Windows.Forms.Padding(4);
+            this.checkBoxModuleEnabled.Location = new System.Drawing.Point(6, 19);
             this.checkBoxModuleEnabled.Name = "checkBoxModuleEnabled";
-            this.checkBoxModuleEnabled.Size = new System.Drawing.Size(119, 20);
+            this.checkBoxModuleEnabled.Size = new System.Drawing.Size(95, 17);
             this.checkBoxModuleEnabled.TabIndex = 3;
             this.checkBoxModuleEnabled.Text = "enable module";
             this.checkBoxModuleEnabled.UseVisualStyleBackColor = true;
@@ -87,37 +86,46 @@ namespace PlenBotLogUploader
             // groupBoxModuleEnabled
             // 
             this.groupBoxModuleEnabled.Controls.Add(this.checkBoxModuleEnabled);
-            this.groupBoxModuleEnabled.Location = new System.Drawing.Point(16, 15);
-            this.groupBoxModuleEnabled.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBoxModuleEnabled.Location = new System.Drawing.Point(12, 12);
             this.groupBoxModuleEnabled.Name = "groupBoxModuleEnabled";
-            this.groupBoxModuleEnabled.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBoxModuleEnabled.Size = new System.Drawing.Size(217, 54);
+            this.groupBoxModuleEnabled.Size = new System.Drawing.Size(163, 44);
             this.groupBoxModuleEnabled.TabIndex = 4;
             this.groupBoxModuleEnabled.TabStop = false;
             this.groupBoxModuleEnabled.Text = "arcdps plugin manager";
             // 
             // groupBoxModuleControls
             // 
+            this.groupBoxModuleControls.Controls.Add(this.checkBoxUseAL);
             this.groupBoxModuleControls.Controls.Add(this.checkBoxEnableNotifications);
             this.groupBoxModuleControls.Controls.Add(this.buttonCheckNow);
             this.groupBoxModuleControls.Controls.Add(this.buttonChangeGW2Location);
             this.groupBoxModuleControls.Enabled = false;
-            this.groupBoxModuleControls.Location = new System.Drawing.Point(16, 101);
-            this.groupBoxModuleControls.Margin = new System.Windows.Forms.Padding(4);
+            this.groupBoxModuleControls.Location = new System.Drawing.Point(12, 62);
             this.groupBoxModuleControls.Name = "groupBoxModuleControls";
-            this.groupBoxModuleControls.Padding = new System.Windows.Forms.Padding(4);
-            this.groupBoxModuleControls.Size = new System.Drawing.Size(217, 124);
+            this.groupBoxModuleControls.Size = new System.Drawing.Size(163, 121);
             this.groupBoxModuleControls.TabIndex = 5;
             this.groupBoxModuleControls.TabStop = false;
             this.groupBoxModuleControls.Text = "Module controls";
             // 
+            // checkBoxUseAL
+            // 
+            this.checkBoxUseAL.AutoSize = true;
+            this.checkBoxUseAL.Location = new System.Drawing.Point(6, 19);
+            this.checkBoxUseAL.Name = "checkBoxUseAL";
+            this.checkBoxUseAL.Size = new System.Drawing.Size(113, 17);
+            this.checkBoxUseAL.TabIndex = 3;
+            this.checkBoxUseAL.Text = "use Addon Loader";
+            this.toolTipAL.SetToolTip(this.checkBoxUseAL, "Check this if you use the Addon Manager for other Addons such as GW2Radial alread" +
+        "y");
+            this.checkBoxUseAL.UseVisualStyleBackColor = true;
+            this.checkBoxUseAL.CheckedChanged += new System.EventHandler(this.checkBoxUseAL_CheckedChanged);
+            // 
             // checkBoxEnableNotifications
             // 
             this.checkBoxEnableNotifications.AutoSize = true;
-            this.checkBoxEnableNotifications.Location = new System.Drawing.Point(8, 59);
-            this.checkBoxEnableNotifications.Margin = new System.Windows.Forms.Padding(4);
+            this.checkBoxEnableNotifications.Location = new System.Drawing.Point(6, 69);
             this.checkBoxEnableNotifications.Name = "checkBoxEnableNotifications";
-            this.checkBoxEnableNotifications.Size = new System.Drawing.Size(189, 20);
+            this.checkBoxEnableNotifications.Size = new System.Drawing.Size(153, 17);
             this.checkBoxEnableNotifications.TabIndex = 2;
             this.checkBoxEnableNotifications.Text = "enable update notifications";
             this.checkBoxEnableNotifications.UseVisualStyleBackColor = true;
@@ -125,10 +133,9 @@ namespace PlenBotLogUploader
             // 
             // buttonCheckNow
             // 
-            this.buttonCheckNow.Location = new System.Drawing.Point(8, 87);
-            this.buttonCheckNow.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonCheckNow.Location = new System.Drawing.Point(6, 92);
             this.buttonCheckNow.Name = "buttonCheckNow";
-            this.buttonCheckNow.Size = new System.Drawing.Size(201, 28);
+            this.buttonCheckNow.Size = new System.Drawing.Size(151, 23);
             this.buttonCheckNow.TabIndex = 1;
             this.buttonCheckNow.Text = "Check now";
             this.buttonCheckNow.UseVisualStyleBackColor = true;
@@ -137,20 +144,19 @@ namespace PlenBotLogUploader
             // labelStatusText
             // 
             this.labelStatusText.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-            this.labelStatusText.Location = new System.Drawing.Point(15, 229);
+            this.labelStatusText.Location = new System.Drawing.Point(11, 186);
             this.labelStatusText.Margin = new System.Windows.Forms.Padding(0);
             this.labelStatusText.Name = "labelStatusText";
-            this.labelStatusText.Size = new System.Drawing.Size(581, 28);
+            this.labelStatusText.Size = new System.Drawing.Size(436, 23);
             this.labelStatusText.TabIndex = 6;
             this.labelStatusText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // buttonShowPluginInfo
             // 
             this.buttonShowPluginInfo.Enabled = false;
-            this.buttonShowPluginInfo.Location = new System.Drawing.Point(240, 197);
-            this.buttonShowPluginInfo.Margin = new System.Windows.Forms.Padding(4);
+            this.buttonShowPluginInfo.Location = new System.Drawing.Point(180, 160);
             this.buttonShowPluginInfo.Name = "buttonShowPluginInfo";
-            this.buttonShowPluginInfo.Size = new System.Drawing.Size(356, 28);
+            this.buttonShowPluginInfo.Size = new System.Drawing.Size(267, 23);
             this.buttonShowPluginInfo.TabIndex = 8;
             this.buttonShowPluginInfo.Text = "Show plugin information";
             this.buttonShowPluginInfo.UseVisualStyleBackColor = true;
@@ -158,17 +164,16 @@ namespace PlenBotLogUploader
             // 
             // FormArcPluginManager
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(612, 268);
+            this.ClientSize = new System.Drawing.Size(459, 218);
             this.Controls.Add(this.buttonShowPluginInfo);
             this.Controls.Add(this.labelStatusText);
             this.Controls.Add(this.groupBoxModuleControls);
             this.Controls.Add(this.groupBoxModuleEnabled);
             this.Controls.Add(this.checkedListBoxArcDpsPlugins);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormArcPluginManager";
@@ -196,5 +201,7 @@ namespace PlenBotLogUploader
         private System.Windows.Forms.Button buttonShowPluginInfo;
         internal System.Windows.Forms.CheckBox checkBoxModuleEnabled;
         internal System.Windows.Forms.CheckBox checkBoxEnableNotifications;
+        internal System.Windows.Forms.CheckBox checkBoxUseAL;
+        private System.Windows.Forms.ToolTip toolTipAL;
     }
 }

--- a/Forms/FormArcPluginManager.Designer.cs
+++ b/Forms/FormArcPluginManager.Designer.cs
@@ -48,7 +48,7 @@ namespace PlenBotLogUploader
             // 
             // buttonChangeGW2Location
             // 
-            this.buttonChangeGW2Location.Location = new System.Drawing.Point(6, 40);
+            this.buttonChangeGW2Location.Location = new System.Drawing.Point(6, 19);
             this.buttonChangeGW2Location.Name = "buttonChangeGW2Location";
             this.buttonChangeGW2Location.Size = new System.Drawing.Size(151, 23);
             this.buttonChangeGW2Location.TabIndex = 0;
@@ -110,7 +110,7 @@ namespace PlenBotLogUploader
             // checkBoxUseAL
             // 
             this.checkBoxUseAL.AutoSize = true;
-            this.checkBoxUseAL.Location = new System.Drawing.Point(6, 19);
+            this.checkBoxUseAL.Location = new System.Drawing.Point(6, 48);
             this.checkBoxUseAL.Name = "checkBoxUseAL";
             this.checkBoxUseAL.Size = new System.Drawing.Size(113, 17);
             this.checkBoxUseAL.TabIndex = 3;

--- a/Forms/FormArcPluginManager.cs
+++ b/Forms/FormArcPluginManager.cs
@@ -204,8 +204,13 @@ namespace PlenBotLogUploader
             if (result.Equals(DialogResult.OK) && !string.IsNullOrWhiteSpace(dialog.FileName))
             {
                 var location = Path.GetDirectoryName(dialog.FileName);
+                if (File.Exists(location + @"\addonLoader.dll"))
+                {
+                    ApplicationSettings.Current.ArcUpdate.UseAL = true;
+                    checkBoxUseAL.Checked = true;
+                    labelStatusText.Text = "Addon Loader found. Using Addon Loader";
+                }
                 ApplicationSettings.Current.GW2Location = location;
-                ApplicationSettings.Current.ArcUpdate.Enabled = true;
                 ApplicationSettings.Current.Save();
                 if (ArcDpsComponent.All.Any(x => x.Type.Equals(ArcDpsComponentType.ArcDps) && x.RenderMode.Equals(ApplicationSettings.Current.ArcUpdate.RenderMode)))
                 {
@@ -233,9 +238,6 @@ namespace PlenBotLogUploader
                     ArcDpsComponent.All.Add(component);
                     ArcDpsComponent.SerialiseAll(ApplicationSettings.LocalDir);
                 }
-                labelStatusText.Text = "";
-                checkedListBoxArcDpsPlugins.Enabled = true;
-                buttonCheckNow.Enabled = true;
                 await StartTimerAsync();
             }
             else
@@ -281,20 +283,13 @@ namespace PlenBotLogUploader
         private void CheckBoxModuleEnabled_CheckedChanged(object sender, EventArgs e)
         {
             var toggle = checkBoxModuleEnabled.Checked;
-            ApplicationSettings.Current.ArcUpdate.Enabled = false;
+            ApplicationSettings.Current.ArcUpdate.Enabled = toggle;
             ApplicationSettings.Current.Save();
             groupBoxModuleControls.Enabled = toggle;
             checkedListBoxArcDpsPlugins.Enabled = toggle;
             if (Visible && toggle && (string.IsNullOrWhiteSpace(ApplicationSettings.Current.GW2Location)))
             {
-                labelStatusText.Text = "You need to select the GW2 Location.";
-                checkedListBoxArcDpsPlugins.Enabled = false;
-                buttonCheckNow.Enabled = false;
-                // ButtonChangeGW2Location_Click(this, new EventArgs());
-            } else
-            {
-                ApplicationSettings.Current.ArcUpdate.Enabled = toggle;
-                ApplicationSettings.Current.Save();
+                ButtonChangeGW2Location_Click(this, new EventArgs());
             }
         }
 

--- a/Forms/FormArcPluginManager.resx
+++ b/Forms/FormArcPluginManager.resx
@@ -120,4 +120,10 @@
   <metadata name="timerCheckUpdates.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTipAL.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>175, 17</value>
+  </metadata>
+  <metadata name="toolTipAL.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>175, 17</value>
+  </metadata>
 </root>

--- a/Forms/FormArcPluginManager.resx
+++ b/Forms/FormArcPluginManager.resx
@@ -123,7 +123,4 @@
   <metadata name="toolTipAL.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>175, 17</value>
   </metadata>
-  <metadata name="toolTipAL.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>175, 17</value>
-  </metadata>
 </root>

--- a/Forms/FormMain.cs
+++ b/Forms/FormMain.cs
@@ -228,6 +228,10 @@ namespace PlenBotLogUploader
                 {
                     if (File.Exists($@"{ApplicationSettings.Current.GW2Location}\Gw2-64.exe") || File.Exists($@"{ApplicationSettings.Current.GW2Location}\Gw2.exe") || File.Exists($@"{ApplicationSettings.Current.GW2Location}\Guild Wars 2.exe"))
                     {
+                        if (ApplicationSettings.Current.ArcUpdate.UseAL)
+                        {
+                            arcPluginManagerLink.checkBoxUseAL.Checked = true;
+                        }
                         if (ApplicationSettings.Current.ArcUpdate.Enabled)
                         {
                             arcPluginManagerLink.checkBoxModuleEnabled.Checked = true;


### PR DESCRIPTION
This change adds an option to enable Addon Loader integration.

It is a bit finicky right now, since you have to have the checkbox enabled BEFORE u set the gw2 path (setting gw2 path downloads arcdps and would replace d3d11.dll from AL if not set before)

I changed the flow a bit, so you will not get a file selector immediately when u enable arcdps module.
Now you have to press the button manually.