### PR TITLE
Updated Boss Data Load Process

### DIFF
--- a/Forms/FormBossData.cs
+++ b/Forms/FormBossData.cs
@@ -108,7 +108,10 @@ namespace PlenBotLogUploader
                 {
                     Bosses.FromJsonFile(Bosses.JsonFileLocation);
                 }
-                Bosses.GetDefaultSettingsForBossesAsDictionary();
+                else
+                {
+                    Bosses.GetDefaultSettingsForBossesAsDictionary();
+                }
             }
             catch
             {


### PR DESCRIPTION
Wrapped the GetDefaultSettingsForBossesAsDictionary in an else block to prevent it from overwritting the local bosses JSON file on launch even when the local file existed and was successfully loaded.